### PR TITLE
Add Python 2 as libv8 depends on it

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -12,6 +12,7 @@ ENV APT_PACKAGES " \
   gcc g++ make patch binutils libc6-dev \
   libjemalloc-dev libffi-dev libssl-dev libyaml-dev zlib1g-dev libgmp-dev \
   libxml2-dev libxslt1-dev libpq-dev libreadline-dev libsqlite3-dev libmysqlclient-dev \
+  python2.7 \
 "
 
 ENV APT_REMOVE_PACKAGES "anacron cron openssh-server postfix"
@@ -21,6 +22,8 @@ RUN apt-get update && apt-get -y dist-upgrade
 RUN apt-get install -y $APT_PACKAGES
 RUN apt-get remove --purge -y $APT_REMOVE_PACKAGES
 RUN apt-get autoremove --purge -y
+
+RUN ln -s /usr/bin/python2.7 /usr/bin/python2
 
 WORKDIR /tmp
 RUN curl -o ruby.tgz \


### PR DESCRIPTION
`libv8` is pretty much in majority of all Rails project gemfiles and latest version is currently failing to build because of `libv8 requires python 2 to be installed in order to build, but
it is currently not available (RuntimeError)` error.

Symlink is necessary because libv8 looks for `python2` binary (https://github.com/cowboyd/libv8/blob/12b2798746c13d7fa3121c888d1bb0bfb2d12b33/ext/libv8/builder.rb#L80)