### PR TITLE
Allow to specify Github personal token for bundler

### DIFF
--- a/onbuild/Dockerfile
+++ b/onbuild/Dockerfile
@@ -6,6 +6,9 @@ CMD ["/sbin/my_init"]
 EXPOSE 8080
 WORKDIR /home/app/webapp
 
+ONBUILD ARG BUNDLE_GITHUB__COM
+ONBUILD ENV BUNDLE_GITHUB__COM ${BUNDLE_GITHUB__COM:-}
+
 ONBUILD COPY Gemfile Gemfile.lock /home/app/webapp/
 ONBUILD COPY vendor/ /home/app/webapp/vendor/
 ONBUILD RUN chown -R app:app Gemfile Gemfile.lock vendor/ && \


### PR DESCRIPTION
This makes it easier to make `bundle install` work if Gemfile contains some private repositories by passing credentials:

`docker build --build-arg BUNDLE_GITHUB__COM=secret-personal-token:x-oauth-basic -t web  .`