### PR TITLE
Add `file` command

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -11,7 +11,7 @@ ENV APT_PACKAGES " \
   git imagemagick gcc g++ make patch binutils libc6-dev libjemalloc-dev \
   libffi-dev libssl-dev libyaml-dev zlib1g-dev libgmp-dev libxml2-dev \
   libxslt1-dev libpq-dev libreadline-dev libsqlite3-dev libmysqlclient-dev \
-  tzdata yarn \
+  tzdata yarn file \
 "
 
 ENV APT_REMOVE_PACKAGES "anacron cron openssh-server postfix"


### PR DESCRIPTION
Paperclip uses it to validate the content type.