### PR TITLE
Remove obsolete `-e` parameter from docker login.

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -2,7 +2,7 @@
 
 . VERSION
 
-docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASSWORD
+docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
 docker tag docker-rails-onbuild $DOCKER_TAG:latest
 docker push $DOCKER_TAG:latest
 docker tag docker-rails-onbuild $DOCKER_TAG:ruby-2.5


### PR DESCRIPTION
`-e` is not supported/needed in recent docker versions.