### PR TITLE
Add option to run bundler with --local flag

### DIFF
--- a/onbuild/Dockerfile
+++ b/onbuild/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /home/app/webapp
 ONBUILD COPY Gemfile Gemfile.lock /home/app/webapp/
 ONBUILD COPY . /home/app/webapp/
 ONBUILD RUN chown -R app:app .
-ONBUILD RUN chpst -u app bundle install --deployment --jobs 4 --without development test
+ONBUILD RUN chpst -u app bundle install ${BUNDLE_LOCAL:+--local} --deployment --jobs 4 --without development test
 ONBUILD RUN find vendor/bundle -name *.gem -delete
 
 ONBUILD ARG BUGSNAG_API_KEY

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -5,6 +5,7 @@ app:
     - REDIS_URL=redis://redis
     - SECRET_KEY_BASE=noop
     - TEST_ENV=hey
+    - BUNDLE_LOCAL=1
   ports:
     - '8080:8080'
   links:


### PR DESCRIPTION
In order to be able to install dependencies from private repositories, without adding the SSH key to the container, let's add the option to run bundler without fetching metadata from remote repositories. `bundle package` needs to be run in the app directory before building the image, for this to work (see `test.sh`).