### PR TITLE
Remove option to run `bundle install` with --local flag

### DIFF
--- a/onbuild/Dockerfile
+++ b/onbuild/Dockerfile
@@ -10,7 +10,7 @@ ONBUILD COPY Gemfile Gemfile.lock /home/app/webapp/
 ONBUILD COPY . /home/app/webapp/
 ONBUILD RUN chown -R app:app .
 ONBUILD RUN chpst -u app bundle install --deployment --jobs 4 --without development test
-ONBUILD RUN find vendor/bundle -name *.gem -delete
+ONBUILD RUN find vendor -name *.gem -delete
 
 ONBUILD ARG BUGSNAG_API_KEY
 ONBUILD ARG BUGSNAG_APP_VERSION

--- a/onbuild/Dockerfile
+++ b/onbuild/Dockerfile
@@ -6,7 +6,6 @@ CMD ["/sbin/my_init"]
 EXPOSE 8080
 WORKDIR /home/app/webapp
 
-ONBUILD ARG BUNDLE_LOCAL
 ONBUILD COPY Gemfile Gemfile.lock /home/app/webapp/
 ONBUILD COPY . /home/app/webapp/
 ONBUILD RUN chown -R app:app .

--- a/onbuild/Dockerfile
+++ b/onbuild/Dockerfile
@@ -14,6 +14,6 @@ ONBUILD RUN find vendor -name *.gem -delete
 
 ONBUILD ARG BUGSNAG_API_KEY
 ONBUILD ARG BUGSNAG_APP_VERSION
-ONBUILD RUN mkdir -p db public/assets log tmp vendor && \
-  chown -R app:app app db public log tmp vendor && chpst -u app /opt/rails-assets.sh && \
-  /opt/custom-services.sh
+ONBUILD RUN mkdir -p db public/assets log tmp vendor
+ONBUILD RUN chpst -u app /opt/rails-assets.sh
+ONBUILD RUN /opt/custom-services.sh

--- a/onbuild/Dockerfile
+++ b/onbuild/Dockerfile
@@ -14,6 +14,6 @@ ONBUILD RUN find vendor -name *.gem -delete
 
 ONBUILD ARG BUGSNAG_API_KEY
 ONBUILD ARG BUGSNAG_APP_VERSION
-ONBUILD RUN mkdir -p db public/assets log tmp vendor
+ONBUILD RUN chpst -u app mkdir -p db public/assets log tmp vendor
 ONBUILD RUN chpst -u app /opt/rails-assets.sh
 ONBUILD RUN /opt/custom-services.sh

--- a/onbuild/Dockerfile
+++ b/onbuild/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /home/app/webapp
 ONBUILD COPY Gemfile Gemfile.lock /home/app/webapp/
 ONBUILD COPY . /home/app/webapp/
 ONBUILD RUN chown -R app:app .
-ONBUILD RUN chpst -u app bundle install ${BUNDLE_LOCAL:+--local} --deployment --jobs 4 --without development test
+ONBUILD RUN chpst -u app bundle install --deployment --jobs 4 --without development test
 ONBUILD RUN find vendor/bundle -name *.gem -delete
 
 ONBUILD ARG BUGSNAG_API_KEY

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -5,7 +5,6 @@ app:
     - REDIS_URL=redis://redis
     - SECRET_KEY_BASE=noop
     - TEST_ENV=hey
-    - BUNDLE_LOCAL=1
   ports:
     - '8080:8080'
   links:


### PR DESCRIPTION
As it turns out, `bundle install --deployment` already implies `--local`, if `bundle package` is run before, which is exactly what we need.

Relevant docs: https://bundler.io/v1.17/bundle_install.html (see bottom)