### PR TITLE
Set user env when running as user with chpst

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/ruby:2.5.3
+      - image: circleci/ruby:2.5.3-node
     steps:
       - setup_remote_docker
 

--- a/onbuild/Dockerfile
+++ b/onbuild/Dockerfile
@@ -14,11 +14,11 @@ WORKDIR /home/app/webapp
 ONBUILD COPY Gemfile Gemfile.lock /home/app/webapp/
 ONBUILD COPY . /home/app/webapp/
 ONBUILD RUN chown -R app:app .
-ONBUILD RUN chpst -u app bundle install --deployment --jobs 4 --without development test
+ONBUILD RUN chpst -U app bundle install --deployment --jobs 4 --without development test
 ONBUILD RUN find vendor -name *.gem -delete
 
 ONBUILD ARG BUGSNAG_API_KEY
 ONBUILD ARG BUGSNAG_APP_VERSION
-ONBUILD RUN chpst -u app mkdir -p db public/assets log tmp vendor
-ONBUILD RUN chpst -u app /opt/rails-assets.sh
+ONBUILD RUN chpst -U app mkdir -p db public/assets log tmp vendor
+ONBUILD RUN chpst -U app /opt/rails-assets.sh
 ONBUILD RUN /opt/custom-services.sh

--- a/test.sh
+++ b/test.sh
@@ -35,24 +35,28 @@ cp -r files/* testapp
 chmod 644 testapp/config/master.key
 (
   cd testapp
-  bundle package --all --no-install
+  bundle package --all
+  rails webpacker:install
+  bin/webpack
 )
 
 # Build container
 docker-compose kill
 docker-compose rm -f
 docker-compose build
-docker-compose up -d
+docker-compose up -d app redis postgres
 
 # Check that app server boots correctly, ENV variables are exposed and sidekiq works properly
-RESULT=$(docker run --network container:test_app_1 appropriate/curl \
-         curl -v -4 --retry 60 --retry-delay 1 --retry-connrefused http://localhost:8080/)
+RESULT=$(docker-compose run curl -s --retry 60 --retry-delay 1 --retry-connrefused http://app:8080/)
 [ "$RESULT" == "ok" ] || exit 1
 
 # Check that static file serving is enabled
-docker run --network container:test_app_1 appropriate/curl \
-  curl -v -4 --retry 60 --retry-delay 1 --retry-connrefused http://localhost:8080/robots.txt \
-  | grep documentation || exit 1
+docker-compose run curl -v \
+                        -4 \
+                        --retry 60 \
+                        --retry-delay 1 \
+                        --retry-connrefused http://app:8080/robots.txt \
+                   | grep documentation || exit 1
 
 # Check that logs are sent to STDOUT
 check_logs appserver "Completed 200 OK" || exit 1
@@ -81,6 +85,6 @@ testapp_run bower -v
 
 # Check that asset gzipping works
 FILE="/home/app/webapp/public/assets/application-*.js"
-testapp_run bash -ec "gzip -dc < $FILE.gz |diff - $FILE"
+testapp_run bash -ec "gzip -dc < $FILE.gz | diff - $FILE"
 
 echo "Tests OK"

--- a/test.sh
+++ b/test.sh
@@ -37,7 +37,6 @@ chmod 644 testapp/config/master.key
   cd testapp
   bundle package --all
   rails webpacker:install
-  bin/webpack
 )
 
 # Build container
@@ -48,7 +47,7 @@ docker-compose up -d app redis postgres
 
 # Check that app server boots correctly, ENV variables are exposed and sidekiq works properly
 RESULT=$(docker-compose run curl -s --retry 60 --retry-delay 1 --retry-connrefused http://app:8080/)
-[ "$RESULT" == "ok" ] || exit 1
+[[ "$RESULT" =~ 'ok' ]] || exit 1
 
 # Check that static file serving is enabled
 docker-compose run curl -v \
@@ -84,7 +83,7 @@ testapp_run npm -v
 testapp_run bower -v
 
 # Check that asset gzipping works
-FILE="/home/app/webapp/public/assets/application-*.js"
+FILE="/home/app/webapp/public/packs/js/application-*.js"
 testapp_run bash -ec "gzip -dc < $FILE.gz | diff - $FILE"
 
 echo "Tests OK"

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,16 +1,20 @@
-app:
-  build: testapp
-  environment:
-    - DATABASE_URL=postgresql://postgres:mysecretpassword@postgres/postgres
-    - REDIS_URL=redis://redis
-    - SECRET_KEY_BASE=noop
-    - TEST_ENV=hey
-  ports:
-    - '8080:8080'
-  links:
-    - redis
-    - postgres
-redis:
-  image: redis:3
-postgres:
-  image: postgres:9.6
+version: "3"
+services:
+  app:
+    build: testapp
+    environment:
+      - DATABASE_URL=postgresql://postgres:mysecretpassword@postgres/postgres
+      - REDIS_URL=redis://redis
+      - SECRET_KEY_BASE=noop
+      - TEST_ENV=hey
+    ports:
+      - '8083:8080'
+    links:
+      - redis
+      - postgres
+  redis:
+    image: redis:4
+  postgres:
+    image: postgres:9.6
+  curl:
+    image: appropriate/curl

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - SECRET_KEY_BASE=noop
       - TEST_ENV=hey
     ports:
-      - '8083:8080'
+      - '8080:8080'
     links:
       - redis
       - postgres


### PR DESCRIPTION
One of our projects looks up a file in the user's `$HOME`, which is set to `/root` when `chpst` is run with `-u $USER`, which makes it fail, because the user doesn't have permission to read anything in there. I changed it, so we run those commands with `-U $USER` instead, so the user's `$HOME` is set properly. At the same time I had to adapt the test to the latest Rails version, which is why this pull-request got slightly bigger.